### PR TITLE
Fix test issues on ammonite-repl.rb

### DIFF
--- a/Formula/a/ammonite-repl.rb
+++ b/Formula/a/ammonite-repl.rb
@@ -15,7 +15,7 @@ class AmmoniteRepl < Formula
     sha256 cellar: :any_skip_relocation, all: "16fae29b00bbce7d4ee0df2dce4b7a1bea69fc8264fc35488896114385fc3da7"
   end
 
-  depends_on "openjdk"
+  depends_on "openjdk@17"
 
   def install
     (libexec/"bin").install Dir["*"].first => "amm"


### PR DESCRIPTION
Ammonite-repl is a Scala project, that has issues with the latest OpenJDK 21 build, so it needs to have a dependency on openjdk@17, and not openjdk

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
